### PR TITLE
chore: standardize MIT license declarations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 daydreamsai
+Copyright (c) 2025-2026 Daydreams AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/facilitator-server/package.json
+++ b/examples/facilitator-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@daydreamsai/facilitator-server",
   "version": "2.0.0",
+  "license": "MIT",
   "private": true,
   "description": "x402 Payment Facilitator Server - Verify and settle x402 payments",
   "type": "module",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@daydreamsai/facilitator-examples",
   "version": "0.0.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "license": "MIT",
   "workspaces": {
     "packages": [
       "examples",


### PR DESCRIPTION
## Summary
- Updated LICENSE copyright to "2025-2026 Daydreams AI"
- Added `"license": "MIT"` to 3 package.json files missing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year range in license file and standardized entity name capitalization
  * Added MIT license metadata to package configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->