### PR TITLE
feat(server): env-gated onBeforeSettle policy + typed abort hooks

### DIFF
--- a/examples/facilitator-server/src/index.ts
+++ b/examples/facilitator-server/src/index.ts
@@ -15,6 +15,12 @@
  * - UPTO_VERIFY_BALANCE_CHECK: "true" to enforce on-chain balance preflight in /verify for upto
  * - BEARER_TOKEN: Required bearer token for /verify and /settle
  * - BEARER_TOKENS: Optional comma-separated bearer token list (overrides BEARER_TOKEN)
+ * - SETTLE_MAX_AMOUNT: optional max settle amount (integer atomic units); abort if exceeded
+ * - SETTLE_PAYTO_ALLOWLIST: optional comma-separated payTo allowlist
+ * - SETTLE_NETWORK_ALLOWLIST: optional comma-separated network (CAIP-2) allowlist
+ * - SETTLE_PREFLIGHT_URL: optional generic HTTP preflight (POST JSON payTo/network/amount)
+ * - SETTLE_PREFLIGHT_TIMEOUT_MS: preflight timeout (default 500)
+ * - SETTLE_PREFLIGHT_FAIL_OPEN: "true" to allow settle if preflight request fails (default fail-closed)
  */
 
 import pg from "pg";
@@ -24,6 +30,10 @@ import { createApp } from "./app.js";
 import { createDrizzleAdapter, createTracking } from "./db.js";
 import { runMigrations } from "./db-migrate.js";
 import { createBearerTokenModule } from "./modules/bearer-token.js";
+import {
+  createSettlePolicyHook,
+  parseSettlePolicyFromEnv,
+} from "./settle-policy.js";
 
 const PORT = parseInt(process.env.PORT || "8090", 10);
 const DATABASE_URL = process.env.DATABASE_URL;
@@ -81,8 +91,17 @@ const tracking = createTracking(pgClient, {
   },
 });
 
+// Optional env-gated settle policy (no-op when unset — same as prior behavior)
+const settlePolicy = parseSettlePolicyFromEnv();
+const settleHooks = settlePolicy
+  ? { onBeforeSettle: createSettlePolicyHook(settlePolicy) }
+  : undefined;
+
 // Facilitator + App
-const facilitator = createFacilitator({ ...defaultSigners });
+const facilitator = createFacilitator({
+  ...defaultSigners,
+  ...(settleHooks ? { hooks: settleHooks } : {}),
+});
 const app = createApp({
   facilitator,
   tracking,
@@ -97,6 +116,24 @@ const app = createApp({
 
 app.listen(PORT);
 console.log(`x402 Facilitator listening on http://localhost:${PORT}`);
+if (settlePolicy) {
+  const parts: string[] = [];
+  if (settlePolicy.maxAmount !== undefined) {
+    parts.push(`maxAmount=${settlePolicy.maxAmount.toString()}`);
+  }
+  if (settlePolicy.payToAllowlist?.length) {
+    parts.push(`payToAllowlist=${settlePolicy.payToAllowlist.length}`);
+  }
+  if (settlePolicy.networkAllowlist?.length) {
+    parts.push(`networkAllowlist=${settlePolicy.networkAllowlist.length}`);
+  }
+  if (settlePolicy.preflightUrl) {
+    parts.push(`preflightUrl=set`);
+  }
+  console.log(`Settle policy: enabled (${parts.join(", ")})`);
+} else {
+  console.log(`Settle policy: off (set SETTLE_MAX_AMOUNT / allowlists / SETTLE_PREFLIGHT_URL)`);
+}
 if (pgClient) {
   console.log(`Resource tracking: PostgreSQL (Drizzle)`);
 } else if (DATABASE_URL) {

--- a/examples/facilitator-server/src/settle-policy.ts
+++ b/examples/facilitator-server/src/settle-policy.ts
@@ -1,0 +1,269 @@
+/**
+ * Env-gated settle policy for the facilitator server hot path.
+ *
+ * When configured, registers as createFacilitator({ hooks: { onBeforeSettle } })
+ * so /settle can abort before on-chain work. All knobs are optional; unset = no-op
+ * (identical to prior behavior).
+ *
+ * No third-party product dependency — optional SETTLE_PREFLIGHT_URL is a generic
+ * HTTP POST any operator can point at their own policy host.
+ */
+
+export type SettleHookAbort = {
+  abort: true;
+  reason: string;
+};
+
+export type SettlePolicyContext = {
+  paymentPayload?: {
+    accepted?: {
+      payTo?: string;
+      network?: string;
+      amount?: string;
+      asset?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  requirements?: {
+    payTo?: string;
+    network?: string;
+    amount?: string;
+    asset?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+export type SettlePolicyConfig = {
+  /** Max settle amount in native atomic units (string or bigint-compatible). */
+  maxAmount?: bigint;
+  /** If non-empty, payTo must be in this list. */
+  payToAllowlist?: string[];
+  /** If non-empty, network must be in this list (exact string match). */
+  networkAllowlist?: string[];
+  /** Optional generic preflight endpoint. */
+  preflightUrl?: string;
+  /** Preflight fetch timeout (ms). Default 500. */
+  preflightTimeoutMs?: number;
+  /**
+   * When preflight URL is set and the request fails (network/5xx/timeout),
+   * abort settle if true (default). Set SETTLE_PREFLIGHT_FAIL_OPEN=true to allow.
+   */
+  failClosedOnPreflightError?: boolean;
+};
+
+function splitCsv(raw: string | undefined): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseAmount(raw: string | undefined): bigint | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    // Atomic units are integers; reject decimals for BigInt safety.
+    if (!/^\d+$/.test(raw.trim())) return undefined;
+    return BigInt(raw.trim());
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalize EVM addresses for allowlist compare; leave base58/other unchanged. */
+function normalizePayTo(payTo: string): string {
+  if (payTo.startsWith("0x") || payTo.startsWith("0X")) {
+    return payTo.toLowerCase();
+  }
+  return payTo;
+}
+
+export function parseSettlePolicyFromEnv(
+  env: NodeJS.ProcessEnv = process.env
+): SettlePolicyConfig | null {
+  const maxRaw = env.SETTLE_MAX_AMOUNT?.trim();
+  const maxAmount = maxRaw ? parseAmount(maxRaw) : undefined;
+  if (maxRaw && maxAmount === undefined) {
+    throw new Error(
+      `SETTLE_MAX_AMOUNT must be a non-negative integer string (atomic units), got: ${maxRaw}`
+    );
+  }
+
+  const payToAllowlist = splitCsv(env.SETTLE_PAYTO_ALLOWLIST).map(normalizePayTo);
+  const networkAllowlist = splitCsv(env.SETTLE_NETWORK_ALLOWLIST);
+  const preflightUrl = env.SETTLE_PREFLIGHT_URL?.trim() || undefined;
+  const timeoutRaw = env.SETTLE_PREFLIGHT_TIMEOUT_MS?.trim();
+  const preflightTimeoutMs = timeoutRaw
+    ? Math.max(1, parseInt(timeoutRaw, 10) || 500)
+    : 500;
+  const failClosedOnPreflightError =
+    env.SETTLE_PREFLIGHT_FAIL_OPEN === "true" ? false : true;
+
+  if (
+    maxAmount === undefined &&
+    payToAllowlist.length === 0 &&
+    networkAllowlist.length === 0 &&
+    !preflightUrl
+  ) {
+    return null;
+  }
+
+  return {
+    maxAmount,
+    payToAllowlist: payToAllowlist.length ? payToAllowlist : undefined,
+    networkAllowlist: networkAllowlist.length ? networkAllowlist : undefined,
+    preflightUrl,
+    preflightTimeoutMs,
+    failClosedOnPreflightError,
+  };
+}
+
+export function resolveSettleFields(ctx: SettlePolicyContext): {
+  payTo: string;
+  network: string;
+  amount: string;
+  asset: string | undefined;
+} {
+  const req = ctx.requirements ?? {};
+  const accepted = ctx.paymentPayload?.accepted ?? {};
+  return {
+    payTo: String(req.payTo ?? accepted.payTo ?? ""),
+    network: String(req.network ?? accepted.network ?? ""),
+    amount: String(req.amount ?? accepted.amount ?? ""),
+    asset:
+      req.asset !== undefined || accepted.asset !== undefined
+        ? String(req.asset ?? accepted.asset)
+        : undefined,
+  };
+}
+
+/**
+ * Synchronous local bounds only (max amount, allowlists). Used by tests and
+ * as the first stage of the async hook.
+ */
+export function evaluateLocalSettlePolicy(
+  config: SettlePolicyConfig,
+  ctx: SettlePolicyContext
+): void | SettleHookAbort {
+  const { payTo, network, amount } = resolveSettleFields(ctx);
+
+  if (config.maxAmount !== undefined && amount) {
+    const amt = parseAmount(amount);
+    if (amt === undefined) {
+      return {
+        abort: true,
+        reason: `settle amount is not a valid integer atomic unit: ${amount}`,
+      };
+    }
+    if (amt > config.maxAmount) {
+      return {
+        abort: true,
+        reason: `amount ${amount} exceeds SETTLE_MAX_AMOUNT (${config.maxAmount.toString()})`,
+      };
+    }
+  }
+
+  if (config.payToAllowlist?.length) {
+    if (!payTo) {
+      return { abort: true, reason: "payTo missing; SETTLE_PAYTO_ALLOWLIST is set" };
+    }
+    const normalized = normalizePayTo(payTo);
+    if (!config.payToAllowlist.includes(normalized)) {
+      return {
+        abort: true,
+        reason: "payTo not in SETTLE_PAYTO_ALLOWLIST",
+      };
+    }
+  }
+
+  if (config.networkAllowlist?.length) {
+    if (!network) {
+      return {
+        abort: true,
+        reason: "network missing; SETTLE_NETWORK_ALLOWLIST is set",
+      };
+    }
+    if (!config.networkAllowlist.includes(network)) {
+      return {
+        abort: true,
+        reason: "network not in SETTLE_NETWORK_ALLOWLIST",
+      };
+    }
+  }
+}
+
+export type PreflightFetch = (
+  url: string,
+  init: RequestInit
+) => Promise<Response>;
+
+/**
+ * Build onBeforeSettle hook. Local bounds first; optional HTTP preflight second.
+ */
+export function createSettlePolicyHook(
+  config: SettlePolicyConfig,
+  fetchImpl: PreflightFetch = fetch
+): (ctx: SettlePolicyContext) => Promise<void | SettleHookAbort> {
+  return async (ctx) => {
+    const local = evaluateLocalSettlePolicy(config, ctx);
+    if (local && "abort" in local && local.abort) return local;
+
+    if (!config.preflightUrl) return;
+
+    const fields = resolveSettleFields(ctx);
+    const controller = new AbortController();
+    const timeoutMs = config.preflightTimeoutMs ?? 500;
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const res = await fetchImpl(config.preflightUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json", accept: "application/json" },
+        body: JSON.stringify({
+          payTo: fields.payTo,
+          network: fields.network,
+          amount: fields.amount,
+          asset: fields.asset,
+        }),
+        signal: controller.signal,
+      });
+
+      if (res.status === 403) {
+        return { abort: true, reason: "preflight denied (HTTP 403)" };
+      }
+
+      if (!res.ok) {
+        if (config.failClosedOnPreflightError !== false) {
+          return {
+            abort: true,
+            reason: `preflight error HTTP ${res.status}`,
+          };
+        }
+        return;
+      }
+
+      const body = (await res.json().catch(() => ({}))) as {
+        allow?: boolean;
+        reason?: string;
+      };
+      if (body.allow === false) {
+        return {
+          abort: true,
+          reason: body.reason?.trim() || "preflight denied",
+        };
+      }
+    } catch (err) {
+      if (config.failClosedOnPreflightError !== false) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          abort: true,
+          reason: `preflight request failed: ${msg}`,
+        };
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/examples/facilitator-server/tests/settle-policy.test.ts
+++ b/examples/facilitator-server/tests/settle-policy.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  createSettlePolicyHook,
+  evaluateLocalSettlePolicy,
+  parseSettlePolicyFromEnv,
+  resolveSettleFields,
+} from "../src/settle-policy.js";
+
+describe("parseSettlePolicyFromEnv", () => {
+  it("returns null when no settle env knobs are set", () => {
+    expect(parseSettlePolicyFromEnv({})).toBeNull();
+  });
+
+  it("parses max amount and allowlists", () => {
+    const cfg = parseSettlePolicyFromEnv({
+      SETTLE_MAX_AMOUNT: "1000",
+      SETTLE_PAYTO_ALLOWLIST: "0xABC, solAddr",
+      SETTLE_NETWORK_ALLOWLIST: "eip155:8453,solana:mainnet",
+    });
+    expect(cfg).not.toBeNull();
+    expect(cfg!.maxAmount).toBe(1000n);
+    expect(cfg!.payToAllowlist).toEqual(["0xabc", "solAddr"]);
+    expect(cfg!.networkAllowlist).toEqual(["eip155:8453", "solana:mainnet"]);
+  });
+
+  it("throws on non-integer SETTLE_MAX_AMOUNT", () => {
+    expect(() =>
+      parseSettlePolicyFromEnv({ SETTLE_MAX_AMOUNT: "1.5" })
+    ).toThrow(/SETTLE_MAX_AMOUNT/);
+  });
+});
+
+describe("evaluateLocalSettlePolicy", () => {
+  const ctx = {
+    requirements: {
+      payTo: "0xAbC",
+      network: "eip155:8453",
+      amount: "500",
+    },
+  };
+
+  it("allows when under max and on allowlists", () => {
+    const result = evaluateLocalSettlePolicy(
+      {
+        maxAmount: 1000n,
+        payToAllowlist: ["0xabc"],
+        networkAllowlist: ["eip155:8453"],
+      },
+      ctx
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("aborts when amount exceeds max", () => {
+    const result = evaluateLocalSettlePolicy({ maxAmount: 100n }, ctx);
+    expect(result).toEqual({
+      abort: true,
+      reason: expect.stringContaining("exceeds SETTLE_MAX_AMOUNT") as unknown as string,
+    });
+    expect(result && "abort" in result && result.abort).toBe(true);
+  });
+
+  it("aborts when payTo not allowlisted", () => {
+    const result = evaluateLocalSettlePolicy(
+      { payToAllowlist: ["0xdead"] },
+      ctx
+    );
+    expect(result && "abort" in result && result.abort).toBe(true);
+  });
+
+  it("aborts when network not allowlisted", () => {
+    const result = evaluateLocalSettlePolicy(
+      { networkAllowlist: ["eip155:1"] },
+      ctx
+    );
+    expect(result && "abort" in result && result.abort).toBe(true);
+  });
+
+  it("resolves fields from paymentPayload.accepted fallback", () => {
+    const fields = resolveSettleFields({
+      paymentPayload: {
+        accepted: {
+          payTo: "Seller",
+          network: "solana:devnet",
+          amount: "9",
+        },
+      },
+    });
+    expect(fields).toEqual({
+      payTo: "Seller",
+      network: "solana:devnet",
+      amount: "9",
+      asset: undefined,
+    });
+  });
+});
+
+describe("createSettlePolicyHook preflight", () => {
+  it("aborts on allow:false JSON body", async () => {
+    const fetchImpl = mock(async () =>
+      new Response(JSON.stringify({ allow: false, reason: "blocked" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    const hook = createSettlePolicyHook(
+      { preflightUrl: "http://policy.test/preflight" },
+      fetchImpl as unknown as typeof fetch
+    );
+    const result = await hook({
+      requirements: { payTo: "x", network: "n", amount: "1" },
+    });
+    expect(result).toEqual({ abort: true, reason: "blocked" });
+  });
+
+  it("aborts on HTTP 403", async () => {
+    const fetchImpl = mock(
+      async () => new Response("no", { status: 403 })
+    );
+    const hook = createSettlePolicyHook(
+      { preflightUrl: "http://policy.test/preflight" },
+      fetchImpl as unknown as typeof fetch
+    );
+    const result = await hook({
+      requirements: { payTo: "x", network: "n", amount: "1" },
+    });
+    expect(result && "abort" in result && result.abort).toBe(true);
+  });
+
+  it("fail-open skips abort on fetch error when configured", async () => {
+    const fetchImpl = mock(async () => {
+      throw new Error("network down");
+    });
+    const hook = createSettlePolicyHook(
+      {
+        preflightUrl: "http://policy.test/preflight",
+        failClosedOnPreflightError: false,
+      },
+      fetchImpl as unknown as typeof fetch
+    );
+    const result = await hook({
+      requirements: { payTo: "x", network: "n", amount: "1" },
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -71,13 +71,83 @@ export interface SvmSignerConfig {
   schemes?: SvmSchemeType[];
 }
 
+/**
+ * Abort settlement/verification by returning this from before-hooks.
+ * Matches the `@x402/core` facilitator contract:
+ *   onBeforeSettle(ctx) => void | { abort: true, reason: string }
+ */
+export type FacilitatorHookAbort = {
+  abort: true;
+  reason: string;
+};
+
+/** Recover a failed verify/settle by returning a synthetic result. */
+export type FacilitatorHookRecover<T> = {
+  recovered: true;
+  result: T;
+};
+
+/**
+ * Structural payment context for lifecycle hooks.
+ * Declared without hard-coupling to every `@x402/core` release shape; the live
+ * facilitator passes at least `paymentPayload` + `requirements`.
+ */
+export interface FacilitatorHookPaymentContext {
+  paymentPayload?: {
+    accepted?: {
+      payTo?: string;
+      network?: string;
+      amount?: string;
+      asset?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  requirements?: {
+    payTo?: string;
+    network?: string;
+    amount?: string;
+    asset?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export type FacilitatorBeforeVerifyHook = (
+  ctx: FacilitatorHookPaymentContext
+) => Promise<void | FacilitatorHookAbort>;
+
+export type FacilitatorAfterVerifyHook = (
+  ctx: FacilitatorHookPaymentContext & { result?: unknown }
+) => Promise<void>;
+
+export type FacilitatorOnVerifyFailureHook = (
+  ctx: FacilitatorHookPaymentContext & { error?: Error }
+) => Promise<void | FacilitatorHookRecover<unknown>>;
+
+export type FacilitatorBeforeSettleHook = (
+  ctx: FacilitatorHookPaymentContext
+) => Promise<void | FacilitatorHookAbort>;
+
+export type FacilitatorAfterSettleHook = (
+  ctx: FacilitatorHookPaymentContext & { result?: unknown }
+) => Promise<void>;
+
+export type FacilitatorOnSettleFailureHook = (
+  ctx: FacilitatorHookPaymentContext & { error?: Error }
+) => Promise<void | FacilitatorHookRecover<unknown>>;
+
 export interface FacilitatorHooks {
-  onBeforeVerify?: (ctx: unknown) => Promise<void>;
-  onAfterVerify?: (ctx: unknown) => Promise<void>;
-  onVerifyFailure?: (ctx: unknown) => Promise<void>;
-  onBeforeSettle?: (ctx: unknown) => Promise<void>;
-  onAfterSettle?: (ctx: unknown) => Promise<void>;
-  onSettleFailure?: (ctx: unknown) => Promise<void>;
+  onBeforeVerify?: FacilitatorBeforeVerifyHook;
+  onAfterVerify?: FacilitatorAfterVerifyHook;
+  onVerifyFailure?: FacilitatorOnVerifyFailureHook;
+  /**
+   * Runs before on-chain settlement. Return `{ abort: true, reason }` to block
+   * the settle (x402 core honors this; do not rely on throw-only).
+   */
+  onBeforeSettle?: FacilitatorBeforeSettleHook;
+  onAfterSettle?: FacilitatorAfterSettleHook;
+  onSettleFailure?: FacilitatorOnSettleFailureHook;
 }
 
 export interface FacilitatorConfig {
@@ -111,6 +181,9 @@ export interface FacilitatorConfig {
  *     schemes: ["exact", "upto"],
  *   }],
  *   hooks: {
+ *     onBeforeSettle: async (ctx) => {
+ *       // Return { abort: true, reason } to block settlement.
+ *     },
  *     onAfterSettle: async (ctx) => analytics.track("settlement", ctx),
  *   },
  * });
@@ -119,24 +192,25 @@ export interface FacilitatorConfig {
 export function createFacilitator(config: FacilitatorConfig): x402Facilitator {
   const facilitator = new x402Facilitator();
 
-  // Register lifecycle hooks
+  // Register lifecycle hooks (x402 core: before-hooks may return { abort, reason })
   if (config.hooks?.onBeforeVerify) {
-    facilitator.onBeforeVerify(config.hooks.onBeforeVerify);
+    // Cast: structural types match runtime; @x402/core pin may lag exported hook generics.
+    facilitator.onBeforeVerify(config.hooks.onBeforeVerify as never);
   }
   if (config.hooks?.onAfterVerify) {
-    facilitator.onAfterVerify(config.hooks.onAfterVerify);
+    facilitator.onAfterVerify(config.hooks.onAfterVerify as never);
   }
   if (config.hooks?.onVerifyFailure) {
-    facilitator.onVerifyFailure(config.hooks.onVerifyFailure);
+    facilitator.onVerifyFailure(config.hooks.onVerifyFailure as never);
   }
   if (config.hooks?.onBeforeSettle) {
-    facilitator.onBeforeSettle(config.hooks.onBeforeSettle);
+    facilitator.onBeforeSettle(config.hooks.onBeforeSettle as never);
   }
   if (config.hooks?.onAfterSettle) {
-    facilitator.onAfterSettle(config.hooks.onAfterSettle);
+    facilitator.onAfterSettle(config.hooks.onAfterSettle as never);
   }
   if (config.hooks?.onSettleFailure) {
-    facilitator.onSettleFailure(config.hooks.onSettleFailure);
+    facilitator.onSettleFailure(config.hooks.onSettleFailure as never);
   }
 
   // Register EVM signers and their schemes

--- a/readme.md
+++ b/readme.md
@@ -596,7 +596,8 @@ const facilitator = createFacilitator({
 
 ### Lifecycle Hooks
 
-Add custom logic at key points:
+Add custom logic at key points. Before-hooks may **abort** by returning
+`{ abort: true, reason: string }` (x402 core contract).
 
 ```typescript
 const facilitator = createFacilitator({
@@ -612,7 +613,7 @@ const facilitator = createFacilitator({
       // Handle verification failures
     },
     onBeforeSettle: async (ctx) => {
-      // Validate before settlement
+      // Return { abort: true, reason } to block settlement before chain work
     },
     onAfterSettle: async (ctx) => {
       // Analytics, notifications
@@ -623,6 +624,22 @@ const facilitator = createFacilitator({
   },
 });
 ```
+
+### Server settle policy (env-gated)
+
+The `x402-facilitator` server wires optional `onBeforeSettle` policy when any of
+these are set (unset = no behavior change):
+
+| Variable | Effect |
+|----------|--------|
+| `SETTLE_MAX_AMOUNT` | Abort if settle amount (atomic units) exceeds this integer |
+| `SETTLE_PAYTO_ALLOWLIST` | Comma-separated payTo allowlist |
+| `SETTLE_NETWORK_ALLOWLIST` | Comma-separated network / CAIP-2 allowlist |
+| `SETTLE_PREFLIGHT_URL` | `POST` JSON `{ payTo, network, amount, asset? }`; body `{ allow: false }` or HTTP 403 aborts |
+| `SETTLE_PREFLIGHT_TIMEOUT_MS` | Preflight timeout (default `500`) |
+| `SETTLE_PREFLIGHT_FAIL_OPEN` | `"true"` to allow settle if preflight request fails (default fail-closed) |
+
+No third-party package is required; point `SETTLE_PREFLIGHT_URL` at any policy host.
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

Adds **optional, env-gated settle policy** on the facilitator server path operators actually run (`npx x402-facilitator` / `examples/facilitator-server`), and aligns library hook types with the real x402 abort contract.

### Server (`createFacilitator` call site)

When any of these are set, registers `hooks.onBeforeSettle` before chain work:

| Env | Effect |
|-----|--------|
| `SETTLE_MAX_AMOUNT` | Abort if amount (integer atomic units) exceeds max |
| `SETTLE_PAYTO_ALLOWLIST` | Comma-separated payTo allowlist |
| `SETTLE_NETWORK_ALLOWLIST` | Comma-separated network / CAIP-2 allowlist |
| `SETTLE_PREFLIGHT_URL` | Generic `POST` `{ payTo, network, amount, asset? }` — `{ allow: false }` or HTTP 403 aborts |
| `SETTLE_PREFLIGHT_TIMEOUT_MS` | Default 500 |
| `SETTLE_PREFLIGHT_FAIL_OPEN` | `"true"` = allow on preflight transport failure (default fail-closed) |

**Unset = no behavior change.** No third-party package dependency; preflight is a generic URL any operator can host.

### Library types (`packages/core` `FacilitatorHooks`)

- Before-hooks typed as `Promise<void | { abort: true; reason: string }>` matching `@x402/core` facilitator contract
- JSDoc notes abort return (throw-only is not the contract)

### Tests

`examples/facilitator-server/tests/settle-policy.test.ts` — local bounds + preflight allow/deny/fail-open (11 cases).

## Why

Facilitator operators need settle-time bounds without forking the server. Agents on a rail inherit policy once the operator sets env — no per-agent install.

## How to verify

```bash
cd examples/facilitator-server
bun test tests/settle-policy.test.ts

# optional runtime:
# SETTLE_MAX_AMOUNT=1 BEARER_TOKEN=… + signers → POST /settle with amount>1 aborts
```

## Notes

- Hot path only (server entry + factory types). No demo-folder contribution.
- Brand-agnostic: `SETTLE_PREFLIGHT_URL` is intentionally generic.