### PR TITLE
Serialise on-chain broadcasts per signer

### DIFF
--- a/.changeset/serialise-signer-broadcasts.md
+++ b/.changeset/serialise-signer-broadcasts.md
@@ -1,0 +1,9 @@
+---
+"@daydreamsai/facilitator": patch
+---
+
+Serialise on-chain broadcasts per signer so concurrent settlements cannot collide on a nonce.
+
+A signer holds one key, and a key has one nonce sequence. The nonce is resolved at send time from the chain's pending count, so two settlements starting before either had landed both read the same number and the second was rejected with `nonce too low` or `replacement transaction underpriced` — surfacing to the caller as `transaction_failed`. Two payers paying at the same moment was enough to trigger it.
+
+Broadcasts from one signer now run one at a time. Only the send is serialised, not the wait for a receipt: the nonce is consumed once the transaction is accepted into the mempool, so the next send starts as soon as the previous one has a hash.

--- a/packages/core/src/signers/__tests__/broadcast-serialisation.test.ts
+++ b/packages/core/src/signers/__tests__/broadcast-serialisation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * A signer holds one key, and a key has one nonce sequence.
+ *
+ * viem resolves the nonce at send time from the chain's pending count, so two broadcasts
+ * started before either has landed both read the same number and the loser is rejected
+ * `nonce too low`. These tests pin the property that makes that impossible: no two broadcasts
+ * from one signer overlap.
+ *
+ * They drive the queue directly rather than through a chain, because the defect is about
+ * ordering rather than about any contract call -- an overlapping pair is the bug whatever it
+ * was trying to send.
+ */
+import { describe, expect, it } from "bun:test";
+
+/**
+ * The serialisation the signer applies to `writeContract` and `sendTransaction`, in the same
+ * shape as `createSignerFromAccount`. Kept in step with that implementation deliberately: a
+ * test that constructed a real signer would need an RPC endpoint and a funded key, and would
+ * then be testing viem rather than this ordering rule.
+ */
+function makeSerialiser() {
+  let queue: Promise<unknown> = Promise.resolve();
+  return function serialize<T>(broadcast: () => Promise<T>): Promise<T> {
+    const result = queue.then(broadcast, broadcast);
+    queue = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  };
+}
+
+describe("signer broadcast serialisation", () => {
+  it("never runs two broadcasts at once", async () => {
+    const serialize = makeSerialiser();
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const broadcast = async (delayMs: number) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      inFlight -= 1;
+    };
+
+    // Deliberately out of order: a later call finishing sooner must not let it start sooner.
+    await Promise.all([
+      serialize(() => broadcast(30)),
+      serialize(() => broadcast(1)),
+      serialize(() => broadcast(15)),
+    ]);
+
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("preserves submission order", async () => {
+    const serialize = makeSerialiser();
+    const finished: number[] = [];
+
+    await Promise.all(
+      [30, 1, 15].map((delayMs, index) =>
+        serialize(async () => {
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          finished.push(index);
+        })
+      )
+    );
+
+    expect(finished).toEqual([0, 1, 2]);
+  });
+
+  it("keeps running after a rejected broadcast", async () => {
+    // The queue must not be poisoned by a failure: a settlement rejected for insufficient
+    // balance is ordinary, and every payment after it would otherwise hang forever.
+    const serialize = makeSerialiser();
+    const finished: string[] = [];
+
+    const failing = serialize(async () => {
+      throw new Error("insufficient balance");
+    });
+    const following = serialize(async () => {
+      finished.push("after");
+      return "ok";
+    });
+
+    await expect(failing).rejects.toThrow("insufficient balance");
+    await expect(following).resolves.toBe("ok");
+    expect(finished).toEqual(["after"]);
+  });
+
+  it("reports each broadcast's own result to its own caller", async () => {
+    const serialize = makeSerialiser();
+
+    const first = serialize(async () => "first-hash");
+    const second = serialize(async () => "second-hash");
+
+    expect(await first).toBe("first-hash");
+    expect(await second).toBe("second-hash");
+  });
+});

--- a/packages/core/src/signers/default.ts
+++ b/packages/core/src/signers/default.ts
@@ -182,6 +182,31 @@ function createSignerFromAccount(
     transport: rpcUrl ? http(rpcUrl) : http(),
   }).extend(publicActions);
 
+  // One signer is one key, and a key has one nonce sequence. viem resolves the nonce at send
+  // time from the chain's pending count, so two broadcasts started before either has landed
+  // both read the same number, build a transaction at it, and the loser is rejected with
+  // `nonce too low` or `replacement transaction underpriced`. Nothing above this layer
+  // prevents that: a facilitator settles whenever a request arrives, and two payers paying at
+  // the same moment is ordinary rather than exceptional.
+  //
+  // Serialising broadcasts per signer makes the collision impossible instead of merely
+  // unlikely. It deliberately covers only the send, not the receipt wait: the nonce is
+  // consumed when the transaction is accepted into the mempool, so the next send may start as
+  // soon as the previous one has a hash, and holding the queue through confirmation would
+  // collapse throughput for no extra safety.
+  //
+  // A rejected broadcast must not poison the queue, so the tail swallows outcomes and the
+  // next call runs either way.
+  let broadcastQueue: Promise<unknown> = Promise.resolve();
+  const serializeBroadcast = <T>(broadcast: () => Promise<T>): Promise<T> => {
+    const result = broadcastQueue.then(broadcast, broadcast);
+    broadcastQueue = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  };
+
   return toFacilitatorEvmSigner({
     getCode: (args: { address: `0x${string}` }) => client.getCode(args),
     address: account.address,
@@ -210,12 +235,14 @@ function createSignerFromAccount(
       functionName: string;
       args: readonly unknown[];
     }) =>
-      client.writeContract({
-        ...args,
-        args: args.args || [],
-      }),
+      serializeBroadcast(() =>
+        client.writeContract({
+          ...args,
+          args: args.args || [],
+        })
+      ),
     sendTransaction: (args: { to: `0x${string}`; data: `0x${string}` }) =>
-      client.sendTransaction(args),
+      serializeBroadcast(() => client.sendTransaction(args)),
     waitForTransactionReceipt: (args: { hash: `0x${string}` }) =>
       client.waitForTransactionReceipt(args),
   });


### PR DESCRIPTION
## The problem

A signer holds one key, and a key has one nonce sequence. `createSignerFromAccount` wraps a viem wallet client and passes `writeContract` and `sendTransaction` straight through with no nonce management, so viem resolves the nonce at send time from the chain's pending count.

Two settlements that start before either has landed therefore both read the same number, both build a transaction at it, and the loser is rejected:

```
nonce too low
replacement transaction underpriced
```

which reaches the caller as `Settlement failed: transaction_failed`.

Nothing above this layer prevents it. A facilitator settles whenever a request arrives, so **two payers paying at the same moment is ordinary rather than exceptional** — the collision is a matter of timing, not of load. It also affects a single settlement in isolation, since `settleUptoPayment` issues two writes (`permit`, then `transferFrom`), widening the window for another settlement to interleave.

### How it surfaced

A smoke test in another service creates two paid tasks concurrently — deliberately, to assert that ids come from the receipt rather than from a predicted nonce. Both payments settle at once, and the run dies at that step every time, reproducibly.

## The fix

Broadcasts from one signer now run one at a time, via a promise queue in `createSignerFromAccount`. Applied at the signer rather than in a settlement module so every scheme is covered, not just the one that exposed it.

Two deliberate properties:

- **Only the send is serialised, not the receipt wait.** The nonce is consumed once the transaction is accepted into the mempool, so the next send may start as soon as the previous one has a hash. Holding the queue through confirmation would collapse throughput for no extra safety.
- **A rejected broadcast does not poison the queue.** An insufficient balance is an ordinary outcome; every payment behind it would otherwise hang forever.

## Tests

`packages/core/src/signers/__tests__/broadcast-serialisation.test.ts` — four cases: no two broadcasts overlap, submission order is preserved, a rejection does not stall the queue, and each caller gets its own result.

Verified non-vacuous: removing the queue makes 2 of the 4 fail, including the central overlap assertion.

`bun run typecheck` and `bun run build` both clean in `packages/core`.

## Alternatives considered

- **A nonce allocator** handing out sequential nonces so concurrent settles broadcast at distinct ones. Higher throughput, materially more machinery — the hard part is deciding what to do when a send fails and the nonce may or may not be spent. Worth it if settle throughput ever becomes the constraint; it is not today, since each settle already awaits two receipts.
- **A pool of signing keys**, one per concurrent settle. Simple, but multiplies funding and key custody.
- **Retrying on nonce errors.** Cheap, and papers over the race rather than removing it — it would still lose under real concurrency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daydreamsai/codesmith/facilitator/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788730903&installation_model_id=429520&pr_number=46&repository=daydreamsai%2Ffacilitator&return_to=https%3A%2F%2Fgithub.com%2Fdaydreamsai%2Ffacilitator%2Fpull%2F46&signature=9c74124fb1e6b4ea1913a9af1e4c20722281d734f33b42b91578ebe3ddc831dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->