### PR TITLE
Keep the transaction hash when a settlement's receipt cannot be read

### DIFF
--- a/.changeset/preserve-hash-when-receipt-unavailable.md
+++ b/.changeset/preserve-hash-when-receipt-unavailable.md
@@ -1,0 +1,9 @@
+---
+"@daydreamsai/facilitator": patch
+---
+
+Return the transaction hash when a settlement was broadcast but its receipt could not be read.
+
+Broadcasting and waiting for a receipt were sharing one `try`, so a dropped RPC connection or a slow receipt — after the transfer was already in the mempool — was reported as a plain failure with `transaction: ""`. The transfer would then land moments later while the caller held no reference to it, leaving money that had moved with nothing to reconcile or refund against.
+
+The two now fail differently. A broadcast that never happened still returns no hash, because no money moved. A broadcast whose outcome is not yet known returns the hash with `errorReason: "settlement_receipt_unavailable"`, so the caller can poll for it rather than write the payment off.

--- a/packages/core/src/upto/evm/settlement.ts
+++ b/packages/core/src/upto/evm/settlement.ts
@@ -161,15 +161,39 @@ export async function settleUptoPayment(
     }
   }
 
-  // Step 2: Execute transferFrom
+  // Step 2: Execute transferFrom.
+  //
+  // The broadcast and the wait for its receipt are separate concerns and must fail
+  // differently. Broadcasting can fail before anything leaves this process, in which case no
+  // money has moved and there is no transaction to name. Waiting can fail after the transfer
+  // is already in the mempool -- a dropped RPC connection, a receipt slower than the client's
+  // timeout -- and that is not the payment failing. It is the payment's outcome being unknown
+  // to us, while the transfer very likely lands moments later.
+  //
+  // Reporting the second as a plain failure with `transaction: ""` was losing the only handle
+  // anyone had on money that had already moved: the caller records no payment reference, so
+  // the transfer cannot afterwards be found, reconciled, or refunded. The hash is therefore
+  // returned even when the receipt is not, so an unknown outcome stays recoverable.
+  let tx: `0x${string}`;
   try {
-    const tx = await signer.writeContract({
+    tx = await signer.writeContract({
       address: erc20Address,
       abi: erc20Abi,
       functionName: "transferFrom",
       args: [payer, getAddress(requirements.payTo), totalSpent],
     });
+  } catch (error) {
+    console.error("Failed to broadcast upto settlement:", error);
+    return {
+      success: false,
+      errorReason: mapTransferErrorReason(error),
+      transaction: "",
+      network: payload.accepted.network,
+      payer,
+    };
+  }
 
+  try {
     const receipt = await signer.waitForTransactionReceipt({ hash: tx });
     if (receipt.status !== "success") {
       return {
@@ -188,11 +212,17 @@ export async function settleUptoPayment(
       payer,
     };
   } catch (error) {
-    console.error("Failed to settle upto payment:", error);
+    // Broadcast, outcome unknown. Deliberately not mapped through
+    // mapTransferErrorReason: that reads revert text to explain why a transfer was rejected,
+    // and nothing here has been rejected -- the chain has not answered yet.
+    console.error(
+      "Upto settlement was broadcast but its receipt could not be read:",
+      { hash: tx, error: errorSummary(error) }
+    );
     return {
       success: false,
-      errorReason: mapTransferErrorReason(error),
-      transaction: "",
+      errorReason: "settlement_receipt_unavailable",
+      transaction: tx,
       network: payload.accepted.network,
       payer,
     };

--- a/packages/core/tests/unit/uptoEvmScheme.test.ts
+++ b/packages/core/tests/unit/uptoEvmScheme.test.ts
@@ -680,6 +680,60 @@ describe("UptoEvmScheme", () => {
         expect(result.errorReason).toBe("invalid_transaction_state");
       });
 
+      it("keeps the transaction hash when the receipt cannot be read", async () => {
+        // The transfer is already in the mempool by the time the receipt lookup fails, so the
+        // money has very likely moved. Returning no hash here would leave the caller with
+        // nothing to reconcile or refund against -- the outcome is unknown, not failed.
+        const writeContractMock = mock()
+          .mockImplementationOnce(() =>
+            Promise.resolve("0xpermittx" as `0x${string}`)
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve("0xtransfertx" as `0x${string}`)
+          );
+
+        mockSigner = createMockSigner({
+          writeContract: writeContractMock,
+          waitForTransactionReceipt: mock(() =>
+            Promise.reject(new Error("HTTP request failed"))
+          ),
+        });
+        scheme = new UptoEvmScheme(mockSigner);
+
+        const result = await scheme.settle(
+          createValidPayload(),
+          createValidRequirements()
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.errorReason).toBe("settlement_receipt_unavailable");
+        expect(result.transaction).toBe("0xtransfertx");
+      });
+
+      it("returns no hash when the broadcast itself never happened", async () => {
+        // The mirror case: nothing left this process, so there is no transaction to name and
+        // no money has moved. The two must stay distinguishable to a caller.
+        const writeContractMock = mock()
+          .mockImplementationOnce(() =>
+            Promise.resolve("0xpermittx" as `0x${string}`)
+          )
+          .mockImplementationOnce(() =>
+            Promise.reject(new Error("Transfer failed"))
+          );
+
+        mockSigner = createMockSigner({ writeContract: writeContractMock });
+        scheme = new UptoEvmScheme(mockSigner);
+
+        const result = await scheme.settle(
+          createValidPayload(),
+          createValidRequirements()
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.transaction).toBe("");
+        expect(result.errorReason).not.toBe("settlement_receipt_unavailable");
+      });
+
       it("returns transaction_failed when transferFrom throws", async () => {
         const writeContractMock = mock()
           .mockImplementationOnce(() =>


### PR DESCRIPTION
## The problem

Broadcasting the transfer and waiting for its receipt shared one `try`:

```ts
const tx = await signer.writeContract({ ...transferFrom });   // hash exists from here
const receipt = await signer.waitForTransactionReceipt({ hash: tx });   // can throw
} catch (error) {
  return { success: false, errorReason: ..., transaction: "" };   // hash discarded
}
```

So a dropped RPC connection, or a receipt slower than the client's timeout, was reported as a plain failure with **no transaction hash** — even though the transfer was already in the mempool and very likely lands moments later.

That conflates two outcomes that are not alike:

| | money moved? | is there a hash? |
| --- | --- | --- |
| broadcast never happened | no | no |
| broadcast succeeded, receipt unreadable | **very likely yes** | **yes, and it was thrown away** |

The second is the damaging one. A caller told `success: false, transaction: ""` records no payment reference, and the transfer that lands a second later cannot afterwards be found, reconciled, or refunded — the hash was the only handle on it.

This is not a rare path. A settlement issues two writes (`permit`, then `transferFrom`), each awaiting a receipt, so the window is as wide as two confirmations on every payment.

## The fix

The two failures are now separate:

- **A broadcast that never happened** still returns `transaction: ""` and the mapped revert reason. No money moved; nothing to name.
- **A broadcast whose receipt cannot be read** returns the hash with `errorReason: "settlement_receipt_unavailable"` — the outcome is *unknown*, not *failed*, and the caller can poll for it.

The new reason is deliberately not routed through `mapTransferErrorReason`. That function reads revert text to explain why a transfer was rejected, and nothing here has been rejected — the chain simply has not answered yet.

## Tests

Two added to `uptoEvmScheme.test.ts`:

- a receipt lookup that throws returns `settlement_receipt_unavailable` **and** the hash
- a broadcast that throws still returns `""`, so the two stay distinguishable

Verified non-vacuous: restoring the old shape makes the first fail.

`bun run typecheck`, `bun run build`, and the full core suite (**534 tests, 0 fail**) are clean.

## Why this matters downstream

A caller settling payments needs to distinguish "the payer was not charged" from "the payer may have been charged and I do not yet know". The first can be retried or refused; the second must be polled and reconciled, and needs a hash to do it with. Returning `""` for both forces the caller to treat an unknown outcome as a definite failure, which is how a settled payment becomes unrecoverable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daydreamsai/codesmith/facilitator/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788732865&installation_model_id=429520&pr_number=47&repository=daydreamsai%2Ffacilitator&return_to=https%3A%2F%2Fgithub.com%2Fdaydreamsai%2Ffacilitator%2Fpull%2F47&signature=c903b2f4b0d2ab9b09d12ddc84f7104980e503a4f1a0ca85a36280198f4b3b77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->