### PR TITLE
Bound how long a settlement waits for its receipt

### DIFF
--- a/.changeset/bound-the-receipt-wait.md
+++ b/.changeset/bound-the-receipt-wait.md
@@ -1,0 +1,9 @@
+---
+"@daydreamsai/facilitator": patch
+---
+
+Bound how long a settlement waits for its receipt.
+
+`waitForTransactionReceipt` was called without a timeout in both signers, and viem waits indefinitely by default. A transaction that stuck in the mempool — underpriced, or queued behind an earlier stuck nonce — held the request open long after the caller's own HTTP timeout had expired, so the caller learned nothing and the connection stayed open on a receipt nobody was waiting for.
+
+The wait is now bounded by `SETTLEMENT_RECEIPT_TIMEOUT_MS` (default 45s, configurable). Timing out is reported as `settlement_receipt_unavailable` with the transaction hash, which says the outcome is unknown rather than that the payment failed, and gives the caller the means to find it later.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -24,6 +24,31 @@ dotenv.config();
 export const PORT = parseInt(process.env.PORT || "8090", 10);
 
 // ============================================================================
+// Settlement Configuration
+// ============================================================================
+
+/**
+ * How long to wait for a settlement transaction's receipt before giving up on reading it.
+ *
+ * Unbounded by default in viem, which is the wrong default here: a transaction that sticks in
+ * the mempool -- underpriced, or queued behind an earlier stuck nonce -- would hold the request
+ * open indefinitely while the caller's own HTTP timeout expired underneath it. The caller then
+ * learns nothing, and the facilitator is still waiting on a receipt nobody is listening for.
+ *
+ * Giving up is not the same as the payment failing. Past this bound the settlement returns
+ * `settlement_receipt_unavailable` **with its transaction hash**, which says the outcome is
+ * unknown and hands back the means to find it later.
+ *
+ * Sized so it expires before a typical caller does rather than after: a caller that has already
+ * timed out cannot use the answer, and holding the connection open past that point only
+ * consumes a socket.
+ */
+export const SETTLEMENT_RECEIPT_TIMEOUT_MS = parseInt(
+  process.env.SETTLEMENT_RECEIPT_TIMEOUT_MS || "45000",
+  10
+);
+
+// ============================================================================
 // CDP Configuration (preferred signer)
 // ============================================================================
 

--- a/packages/core/src/signers/cdp.ts
+++ b/packages/core/src/signers/cdp.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CdpClient, EvmServerAccount } from "@coinbase/cdp-sdk";
+import { SETTLEMENT_RECEIPT_TIMEOUT_MS } from "../config.js";
 import { toFacilitatorEvmSigner, type FacilitatorEvmSigner } from "@x402/evm";
 import {
   createPublicClient,
@@ -331,10 +332,14 @@ export function createCdpEvmSigner(config: CdpSignerConfig): FacilitatorEvmSigne
      * Wait for a transaction to be mined
      */
     waitForTransactionReceipt: async (args: { hash: Hex }) => {
+      // retryCount/retryDelay govern RPC request retries, not how long the receipt is waited
+      // for -- without an explicit timeout that wait is unbounded. See
+      // SETTLEMENT_RECEIPT_TIMEOUT_MS.
       return publicClient.waitForTransactionReceipt({
         hash: args.hash,
         retryCount: 3,
         retryDelay: 5000,
+        timeout: SETTLEMENT_RECEIPT_TIMEOUT_MS,
       });
     },
   });

--- a/packages/core/src/signers/default.ts
+++ b/packages/core/src/signers/default.ts
@@ -13,6 +13,8 @@ import {
 } from "@x402/svm";
 import { createWalletClient, defineChain, http, publicActions, type Chain } from "viem";
 import { privateKeyToAccount, type PrivateKeyAccount } from "viem/accounts";
+
+import { SETTLEMENT_RECEIPT_TIMEOUT_MS } from "../config.js";
 import {
   abstract,
   abstractTestnet,
@@ -243,7 +245,13 @@ function createSignerFromAccount(
       ),
     sendTransaction: (args: { to: `0x${string}`; data: `0x${string}` }) =>
       serializeBroadcast(() => client.sendTransaction(args)),
+    // Bounded on purpose -- viem waits indefinitely by default, which outlives every caller
+    // and leaves a request open on a receipt nobody is waiting for. See
+    // SETTLEMENT_RECEIPT_TIMEOUT_MS.
     waitForTransactionReceipt: (args: { hash: `0x${string}` }) =>
-      client.waitForTransactionReceipt(args),
+      client.waitForTransactionReceipt({
+        ...args,
+        timeout: SETTLEMENT_RECEIPT_TIMEOUT_MS,
+      }),
   });
 }

--- a/packages/core/tests/unit/uptoEvmScheme.test.ts
+++ b/packages/core/tests/unit/uptoEvmScheme.test.ts
@@ -710,6 +710,41 @@ describe("UptoEvmScheme", () => {
         expect(result.transaction).toBe("0xtransfertx");
       });
 
+      it("treats a receipt timeout as an unknown outcome, not a failure", async () => {
+        // viem raises WaitForTransactionReceiptTimeoutError once the bound in
+        // SETTLEMENT_RECEIPT_TIMEOUT_MS elapses. That is the case the bound exists to produce,
+        // and it must land in the same branch as any other unreadable receipt: the transfer is
+        // in the mempool and may still mine, so the hash is what makes it recoverable.
+        const writeContractMock = mock()
+          .mockImplementationOnce(() =>
+            Promise.resolve("0xpermittx" as `0x${string}`)
+          )
+          .mockImplementationOnce(() =>
+            Promise.resolve("0xtransfertx" as `0x${string}`)
+          );
+
+        mockSigner = createMockSigner({
+          writeContract: writeContractMock,
+          waitForTransactionReceipt: mock(() =>
+            Promise.reject(
+              new Error(
+                "Timed out while waiting for transaction with hash \"0xtransfertx\" to be confirmed."
+              )
+            )
+          ),
+        });
+        scheme = new UptoEvmScheme(mockSigner);
+
+        const result = await scheme.settle(
+          createValidPayload(),
+          createValidRequirements()
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.errorReason).toBe("settlement_receipt_unavailable");
+        expect(result.transaction).toBe("0xtransfertx");
+      });
+
       it("returns no hash when the broadcast itself never happened", async () => {
         // The mirror case: nothing left this process, so there is no transaction to name and
         // no money has moved. The two must stay distinguishable to a caller.

--- a/readme.md
+++ b/readme.md
@@ -364,6 +364,14 @@ curl -H "x-wallet-address: 0xYourWalletAddress" \
 
 \*Required when CDP credentials are not configured.
 
+**Settlement**
+
+| Variable                        | Required | Default | Description                                                                 |
+| ------------------------------- | -------- | ------- | --------------------------------------------------------------------------- |
+| `SETTLEMENT_RECEIPT_TIMEOUT_MS` | No       | `45000` | How long to wait for a settlement receipt before reporting an unknown outcome |
+
+Past this bound a settlement returns `settlement_receipt_unavailable` **with its transaction hash**, rather than waiting indefinitely. That is not the payment failing — the transfer is in the mempool and may still mine — so the hash is returned to make it recoverable. Set it below the timeout your own callers use: an answer that arrives after the caller has given up cannot be acted on.
+
 **Starknet Paymaster (Exact Scheme)**
 
 | Variable                           | Required | Default | Description                                      |


### PR DESCRIPTION
## The problem

Both signers called `waitForTransactionReceipt` with no timeout:

```ts
// default.ts
waitForTransactionReceipt: (args) => client.waitForTransactionReceipt(args)

// cdp.ts
publicClient.waitForTransactionReceipt({ hash, retryCount: 3, retryDelay: 5000 })
```

viem waits **indefinitely** by default. The CDP signer's `retryCount`/`retryDelay` do not change that — they govern RPC request retries, not how long the receipt is awaited.

So a transaction that sticks in the mempool holds the request open forever. The caller's own HTTP timeout expires long before, having learned nothing, while the facilitator goes on waiting for a receipt nobody is listening for and holding a socket to prove it.

**Sticking is not exotic.** Nonces mine in order, so one underpriced transaction stalls every transaction behind it on the same key — and with no fee control anywhere in the package, none of them can be repriced.

## The fix

The wait is bounded by `SETTLEMENT_RECEIPT_TIMEOUT_MS`, default 45s, configurable.

The default is deliberately **shorter than a typical caller's own timeout**. An answer that arrives after the caller has given up cannot be acted on, so waiting past that point costs a connection and buys nothing.

Timing out is **not** reported as the payment failing. It reaches the same branch as any other unreadable receipt and returns `settlement_receipt_unavailable` **with the transaction hash** — the outcome is unknown, the transfer may still mine, and the hash is what keeps it findable.

## Tests

One added to `uptoEvmScheme.test.ts`: a receipt wait that rejects with viem's timeout error returns `settlement_receipt_unavailable` and preserves the hash.

Full core suite: **535 tests, 0 fail.** `typecheck` and `build` clean. `SETTLEMENT_RECEIPT_TIMEOUT_MS` documented in the readme's environment table.

## What this does not fix

A bounded wait stops the facilitator hanging. It does **not** unblock the nonce — a stuck transaction still sits at its nonce and still blocks everything behind it, and nothing here can reprice it.

Fixing that properly needs durable per-nonce state (which nonce, what fee it paid, how many attempts), replacement broadcasts escalating from the *previous* fee rather than a fresh oracle read, a cap, and a clearing transfer when escalation reaches it. That is a reconciler, and it deserves its own design rather than being appended to a bug fix.

Until then the recovery is manual: send a replacement at the stuck nonce from the signer's key with higher gas. Worth a runbook entry, since the failure is rare, shared across all payers, and currently silent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daydreamsai/codesmith/facilitator/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788735603&installation_model_id=429520&pr_number=48&repository=daydreamsai%2Ffacilitator&return_to=https%3A%2F%2Fgithub.com%2Fdaydreamsai%2Ffacilitator%2Fpull%2F48&signature=29b7b73ef80d52c4a01175fa0d48adc01832dc52c430ee6c55950c860dbfee1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->